### PR TITLE
Remove unneeded `return` statement

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -24,11 +24,11 @@ pub struct Packet {
 
 impl Default for Packet {
     fn default() -> Packet {
-        return Packet {
+        Packet {
             time: 0,
             direction: SerialDirection::SEND,
             payload: "".to_string(),
-        };
+        }
     }
 }
 
@@ -41,10 +41,10 @@ pub struct DataContainer {
 
 impl Default for DataContainer {
     fn default() -> DataContainer {
-        return DataContainer {
+        DataContainer {
             time: vec![],
             dataset: vec![vec![]],
             raw_traffic: vec![],
-        };
+        }
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -53,13 +53,13 @@ pub struct GuiSettingsContainer {
 
 impl GuiSettingsContainer {
     pub fn default() -> GuiSettingsContainer {
-        return GuiSettingsContainer {
+        GuiSettingsContainer {
             device: "".to_string(),
             baud: 115_200,
             debug: true,
             x: 1600.0,
             y: 900.0,
-        };
+        }
     }
 }
 


### PR DESCRIPTION
This PR removes return statements at the end of a block. 
