### PR TITLE
Refactor GuiSettingsContainer load/save

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,6 +1,6 @@
 use crate::data::{DataContainer, SerialDirection};
 use crate::toggle::toggle;
-use crate::{vec2, APP_INFO};
+use crate::{vec2, APP_INFO, PREFS_KEY};
 use core::f32;
 use eframe::egui::panel::Side;
 use eframe::egui::plot::{Legend, Line, Plot, PlotPoints};
@@ -568,12 +568,8 @@ impl eframe::App for MyApp {
     }
 
     fn save(&mut self, _storage: &mut dyn Storage) {
-        let prefs_key = "config/gui";
-        match self.gui_conf.save(&APP_INFO, prefs_key) {
-            Ok(_) => {}
-            Err(err) => {
-                println!("gui settings save failed: {:?}", err);
-            }
+        if let Err(err) = self.gui_conf.save(&APP_INFO, PREFS_KEY) {
+            println!("gui settings save failed: {:?}", err);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ const APP_INFO: AppInfo = AppInfo {
     name: "Serial Monitor",
     author: "Linus Leo Stöckli",
 };
+const PREFS_KEY: &str = "config/gui";
 
 fn split(payload: &str) -> Vec<f32> {
     let mut split_data: Vec<&str> = vec![];
@@ -120,16 +121,7 @@ fn main_thread(
 }
 
 fn main() {
-    let mut gui_settings = GuiSettingsContainer::default();
-    let prefs_key = "config/gui";
-    if let Ok(load_result) = GuiSettingsContainer::load(&APP_INFO, prefs_key) {
-        gui_settings = load_result;
-    } else {
-        // save default settings
-        if gui_settings.save(&APP_INFO, prefs_key).is_err() {
-            println!("failed to save gui_settings");
-        }
-    }
+    let gui_settings = load_gui_settings();
 
     let device_lock = Arc::new(RwLock::new(gui_settings.device.clone()));
     let devices_lock = Arc::new(RwLock::new(vec![gui_settings.device.clone()]));
@@ -212,4 +204,15 @@ fn main() {
     ) {
         println!("error: {e:?}");
     }
+}
+
+fn load_gui_settings() -> GuiSettingsContainer {
+    let gui_settings = GuiSettingsContainer::load(&APP_INFO, PREFS_KEY).unwrap_or_default();
+    if gui_settings == GuiSettingsContainer::default() {
+        // save default settings
+        if gui_settings.save(&APP_INFO, PREFS_KEY).is_err() {
+            println!("failed to save gui_settings");
+        }
+    }
+    gui_settings
 }


### PR DESCRIPTION
I believe `prefs_key` is shared between `main` and `gui`. To ensure consistency and avoid unintended modifications, this PR proposes declaring prefs_key as a `constant` in main.

Furthermore, this PR introduces a new function called `load_gui_settings`. This function is designed to handle loading settings specific to the GUI component. By encapsulating this functionality in a separate function, we can improve the modularity and reusability.