### PR TITLE
Refactor `print_to_console`

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -25,7 +25,6 @@ pub enum Print {
     Message(String),
     Error(String),
     Debug(String),
-    Task(String),
     OK(String),
 }
 
@@ -68,14 +67,6 @@ impl Print {
                     color,
                 })
             }
-            Print::Task(s) => {
-                let color = egui::Color32::WHITE;
-                Some(ScrollAreaMessage {
-                    label: "[   ] ".to_owned(),
-                    content: s.to_owned(),
-                    color,
-                })
-            }
             Print::OK(s) => {
                 let color = egui::Color32::GREEN;
                 Some(ScrollAreaMessage {
@@ -94,18 +85,14 @@ pub struct ScrollAreaMessage {
     color: egui::Color32,
 }
 
-pub fn print_to_console(print_lock: &Arc<RwLock<Vec<Print>>>, message: Print) -> usize {
-    let mut length: usize = 0;
-    if let Ok(mut write_guard) = print_lock.write() {
-        write_guard.push(message);
-        length = write_guard.len() - 1;
-    }
-    length
-}
-
-pub fn update_in_console(print_lock: &Arc<RwLock<Vec<Print>>>, message: Print, index: usize) {
-    if let Ok(mut write_guard) = print_lock.write() {
-        write_guard[index] = message;
+pub fn print_to_console(print_lock: &Arc<RwLock<Vec<Print>>>, message: Print) {
+    match print_lock.write() {
+        Ok(mut write_guard) => {
+            write_guard.push(message);
+        }
+        Err(e) => {
+            eprintln!("Error while writing to print_lock: {}", e);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::time::Duration;
 
-use crate::gui::{load_gui_settings, print_to_console, update_in_console, MyApp, Print};
+use crate::gui::{load_gui_settings, print_to_console, MyApp, Print};
 use crate::io::save_to_csv;
 use crate::serial::serial_thread;
 
@@ -92,22 +92,17 @@ fn main_thread(
         }
 
         if let Ok(file_path) = save_rx.recv_timeout(Duration::from_millis(10)) {
-            let print_index = print_to_console(
-                &print_lock,
-                Print::Task(format!("saving data file to {:?} ...", file_path)),
-            );
             match save_to_csv(&data, &file_path) {
                 Ok(_) => {
-                    update_in_console(
+                    print_to_console(
                         &print_lock,
                         Print::OK(format!("saved data file to {:?} ", file_path)),
-                        print_index,
                     );
                 }
                 Err(e) => {
                     print_to_console(
                         &print_lock,
-                        Print::Error(format!("failed to save file: {e:?}")),
+                        Print::Error(format!("failed to save file to {:?}: {:?}", file_path, e)),
                     );
                 }
             }


### PR DESCRIPTION
This fixes #40 

Looking at the app's current design, I figured printing out the error message within the `print_to_console` function may be appropriate. This makes the code simple and straightforward. 

In the future, if we want the caller to take some action based on the error, it may be more appropriate to return a `Result<(), std::sync::PoisonError<std::sync::RwLockWriteGuard<Vec<Print>>>>` and let the caller handle the error.
