### PR TITLE
Improve clarity by directly calling `devices.contains(&device)`

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -133,8 +133,6 @@ pub fn serial_thread(
                 }
             }
 
-            let dev_is_con = devices.contains(&device);
-
             if reconnect {
                 print_to_console(
                     &print_lock,
@@ -146,7 +144,7 @@ pub fn serial_thread(
                 break 'connected_loop;
             }
 
-            if !dev_is_con {
+            if !devices.contains(&device) {
                 print_to_console(
                     &print_lock,
                     Print::Error(format!(


### PR DESCRIPTION
In my opinion, `dev_is_con` is not a very descriptive name for a variable. A more readable approach might be to directly call `devices.contains(&device)` instead. This would make the code clearer and easier to understand.