### PR TITLE
Refactor device name and baud rate handling

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,5 +1,6 @@
 use crate::data::{DataContainer, SerialDirection};
 use crate::toggle::toggle;
+use crate::Device;
 use crate::{vec2, APP_INFO, PREFS_KEY};
 use core::f32;
 use eframe::egui::panel::Side;
@@ -150,9 +151,8 @@ pub struct MyApp {
     data: DataContainer,
     gui_conf: GuiSettingsContainer,
     print_lock: Arc<RwLock<Vec<Print>>>,
-    device_lock: Arc<RwLock<String>>,
+    device_lock: Arc<RwLock<Device>>,
     devices_lock: Arc<RwLock<Vec<String>>>,
-    baud_lock: Arc<RwLock<u32>>,
     connected_lock: Arc<RwLock<bool>>,
     data_lock: Arc<RwLock<DataContainer>>,
     save_tx: Sender<PathBuf>,
@@ -172,9 +172,8 @@ impl MyApp {
     pub fn new(
         print_lock: Arc<RwLock<Vec<Print>>>,
         data_lock: Arc<RwLock<DataContainer>>,
-        device_lock: Arc<RwLock<String>>,
+        device_lock: Arc<RwLock<Device>>,
         devices_lock: Arc<RwLock<Vec<String>>>,
-        baud_lock: Arc<RwLock<u32>>,
         connected_lock: Arc<RwLock<bool>>,
         gui_conf: GuiSettingsContainer,
         save_tx: Sender<PathBuf>,
@@ -193,7 +192,6 @@ impl MyApp {
             connected_lock,
             device_lock,
             devices_lock,
-            baud_lock,
             print_lock,
             gui_conf,
             data_lock,
@@ -453,16 +451,10 @@ impl MyApp {
                         if ui.button(connect_text).clicked() {
                             if let Ok(mut write_guard) = self.device_lock.write() {
                                 if self.ready {
-                                    *write_guard = "".to_string();
+                                    write_guard.name.clear();
                                 } else {
-                                    *write_guard = self.device.clone();
-                                }
-                            }
-                            if let Ok(mut write_guard) = self.baud_lock.write() {
-                                if self.ready {
-                                    // do nothing
-                                } else {
-                                    *write_guard = self.baud_rate;
+                                    write_guard.name = self.device.clone();
+                                    write_guard.baud_rate = self.baud_rate;
                                 }
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,12 @@ const APP_INFO: AppInfo = AppInfo {
 };
 const PREFS_KEY: &str = "config/gui";
 
+#[derive(Default, Debug)]
+pub struct Device {
+    pub name: String,
+    pub baud_rate: u32,
+}
+
 fn split(payload: &str) -> Vec<f32> {
     let mut split_data: Vec<&str> = vec![];
     for s in payload.split(':') {
@@ -118,9 +124,8 @@ fn main_thread(
 fn main() {
     let gui_settings = load_gui_settings();
 
-    let device_lock = Arc::new(RwLock::new(gui_settings.device.clone()));
+    let device_lock = Arc::new(RwLock::new(Device::default()));
     let devices_lock = Arc::new(RwLock::new(vec![gui_settings.device.clone()]));
-    let baud_lock = Arc::new(RwLock::new(gui_settings.baud));
     let raw_data_lock = Arc::new(RwLock::new(vec![Packet::default()]));
     let data_lock = Arc::new(RwLock::new(DataContainer::default()));
     let print_lock = Arc::new(RwLock::new(vec![Print::Empty]));
@@ -132,7 +137,6 @@ fn main() {
 
     let serial_device_lock = device_lock.clone();
     let serial_devices_lock = devices_lock.clone();
-    let serial_baud_lock = baud_lock.clone();
     let serial_raw_data_lock = raw_data_lock.clone();
     let serial_print_lock = print_lock.clone();
     let serial_connected_lock = connected_lock.clone();
@@ -143,7 +147,6 @@ fn main() {
             send_rx,
             serial_device_lock,
             serial_devices_lock,
-            serial_baud_lock,
             serial_raw_data_lock,
             serial_print_lock,
             serial_connected_lock,
@@ -174,7 +177,6 @@ fn main() {
     let gui_data_lock = data_lock;
     let gui_device_lock = device_lock;
     let gui_devices_lock = devices_lock;
-    let gui_baud_lock = baud_lock;
     let gui_connected_lock = connected_lock;
     let gui_print_lock = print_lock;
 
@@ -188,7 +190,6 @@ fn main() {
                 gui_data_lock,
                 gui_device_lock,
                 gui_devices_lock,
-                gui_baud_lock,
                 gui_connected_lock,
                 gui_settings,
                 save_tx,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -165,7 +165,7 @@ pub fn serial_thread(
     }
 }
 
-fn get_device(devices_lock: Arc<RwLock<Vec<String>>>, d_lock: Arc<RwLock<Device>>) -> Device {
+fn get_device(devices_lock: Arc<RwLock<Vec<String>>>, device_lock: Arc<RwLock<Device>>) -> Device {
     loop {
         let devices: Vec<String> = serialport::available_ports()
             .unwrap()
@@ -177,7 +177,7 @@ fn get_device(devices_lock: Arc<RwLock<Vec<String>>>, d_lock: Arc<RwLock<Device>
             *write_guard = devices.clone();
         }
 
-        if let Ok(device) = d_lock.read() {
+        if let Ok(device) = device_lock.read() {
             if devices.contains(&device.name) {
                 return Device {
                     name: device.name.clone(),


### PR DESCRIPTION
This pull request replaces `device_lock: Arc<RwLock<String>>` and `baud_lock: Arc<RwLock<u32>>` with `device_lock: Arc<RwLock<Device>>`.