### PR TITLE
Add `CsvOptions` struct for improved readability

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -16,8 +16,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::data::{DataContainer, SerialDirection};
 use crate::toggle::toggle;
-use crate::Device;
 use crate::{vec2, APP_INFO, PREFS_KEY};
+use crate::{CsvOptions, Device};
 
 const MAX_FPS: f64 = 60.0;
 
@@ -167,7 +167,7 @@ pub struct MyApp {
     devices_lock: Arc<RwLock<Vec<String>>>,
     connected_lock: Arc<RwLock<bool>>,
     data_lock: Arc<RwLock<DataContainer>>,
-    save_tx: Sender<(PathBuf, bool)>,
+    save_tx: Sender<CsvOptions>,
     send_tx: Sender<String>,
     clear_tx: Sender<bool>,
     history: Vec<String>,
@@ -188,7 +188,7 @@ impl MyApp {
         devices_lock: Arc<RwLock<Vec<String>>>,
         connected_lock: Arc<RwLock<bool>>,
         gui_conf: GuiSettingsContainer,
-        save_tx: Sender<(PathBuf, bool)>,
+        save_tx: Sender<CsvOptions>,
         send_tx: Sender<String>,
         clear_tx: Sender<bool>,
     ) -> Self {
@@ -471,10 +471,10 @@ impl MyApp {
                                 if let Some(path) = rfd::FileDialog::new().save_file() {
                                     self.picked_path = path;
                                     self.picked_path.set_extension("csv");
-                                    if let Err(e) = self.save_tx.send((
-                                        self.picked_path.clone(),
-                                        self.gui_conf.save_absolute_time,
-                                    )) {
+                                    if let Err(e) = self.save_tx.send(CsvOptions {
+                                        file_path: self.picked_path.clone(),
+                                        save_absolute_time: self.gui_conf.save_absolute_time,
+                                    }) {
                                         print_to_console(
                                             &self.print_lock,
                                             Print::Error(format!(

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,18 +1,13 @@
 use std::error::Error;
-use std::path::PathBuf;
 
 use csv::WriterBuilder;
 
-use crate::DataContainer;
+use crate::{CsvOptions, DataContainer};
 
-pub fn save_to_csv(
-    data: &DataContainer,
-    file_path: &PathBuf,
-    save_absolute_time: bool,
-) -> Result<(), Box<dyn Error>> {
+pub fn save_to_csv(data: &DataContainer, csv_options: &CsvOptions) -> Result<(), Box<dyn Error>> {
     let mut wtr = WriterBuilder::new()
         .has_headers(false)
-        .from_path(file_path)?;
+        .from_path(&csv_options.file_path)?;
     // serialize does not work, so we do it with a loop..
     let mut header = vec!["Time [ms]".to_string()];
     for (i, _value) in data.dataset.iter().enumerate() {
@@ -20,7 +15,7 @@ pub fn save_to_csv(
     }
     wtr.write_record(header)?;
     for j in 0..data.dataset[0].len() {
-        let time = if save_absolute_time {
+        let time = if csv_options.save_absolute_time {
             data.absolute_time[j].to_string()
         } else {
             data.time[j].to_string()


### PR DESCRIPTION
I propose creating a new struct called `CsvOptions` that contains a set of options for saving data to a CSV file. Using `CsvOptions` will improve the readability of the code and better communicate the intention of the options being passed compared to using a tuple like `(PathBuf, bool)`. The struct contains the necessary fields to specify the path to the CSV file and whether timestamps should be formatted as absolute or relative times.