### PR TITLE
Add option to display multiple plots, and resize the plot panel

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -370,16 +370,19 @@ impl MyApp {
                             self.plot_location = plot_inner.response.rect;
                         }
                         let separator_response = ui.separator();
-                        let resize_y = ui
+                        let separator = ui
                             .interact(
                                 separator_response.rect,
                                 separator_response.id,
                                 Sense::click_and_drag(),
                             )
-                            .on_hover_cursor(egui::CursorIcon::ResizeVertical)
-                            .drag_delta()
-                            .y;
+                            .on_hover_cursor(egui::CursorIcon::ResizeVertical);
 
+                        let resize_y = separator.drag_delta().y;
+
+                        if separator.double_clicked() {
+                            self.plot_serial_display_ratio = 0.45;
+                        }
                         self.plot_serial_display_ratio = (self.plot_serial_display_ratio
                             + resize_y / panel_height)
                             .clamp(0.1, 0.9);

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -174,7 +174,6 @@ pub struct MyApp {
     device_idx: usize,
     serial_devices: SerialDevices,
     plotting_range: usize,
-    number_of_plots: usize,
     plot_serial_display_ratio: f32,
     console: Vec<Print>,
     picked_path: PathBuf,
@@ -238,7 +237,6 @@ impl MyApp {
             send_tx,
             clear_tx,
             plotting_range: usize::MAX,
-            number_of_plots: 1,
             plot_serial_display_ratio: 0.45,
             command: "".to_string(),
             show_sent_cmds: true,
@@ -310,7 +308,7 @@ impl MyApp {
             let panel_height = ui.available_size().y;
             let height = ui.available_size().y * self.plot_serial_display_ratio;
             let plots_height = height;
-            let plot_height = plots_height / (self.number_of_plots as f32);
+            let plot_height = plots_height / (self.serial_devices.number_of_plots as f32);
             let spacing = 5.0;
             let width = ui.available_size().x - 2.0 * border - RIGHT_PANEL_WIDTH;
 
@@ -341,7 +339,7 @@ impl MyApp {
                     let t_fmt = |x, _range: &RangeInclusive<f64>| format!("{:4.2} s", x);
 
                     let plots_ui = ui.vertical(|ui| {
-                        for graph_idx in 0..self.number_of_plots {
+                        for graph_idx in 0..self.serial_devices.number_of_plots {
                             if graph_idx != 0 {
                                 ui.separator();
                             }
@@ -684,13 +682,15 @@ impl MyApp {
 
                             ui.horizontal(|ui| {
                                 if ui.button("<").clicked() {
-                                    self.number_of_plots = (self.number_of_plots - 1).clamp(1, 10);
+                                    self.serial_devices.number_of_plots =
+                                        (self.serial_devices.number_of_plots - 1).clamp(1, 10);
                                 }
-                                ui.add(egui::DragValue::new(&mut self.number_of_plots)
+                                ui.add(egui::DragValue::new(&mut self.serial_devices.number_of_plots)
                                     .clamp_range(1..=10))
                                     .on_hover_text("Select the number of plots to be shown.");
                                 if ui.button(">").clicked() {
-                                    self.number_of_plots = (self.number_of_plots + 1).clamp(1, 10);
+                                    self.serial_devices.number_of_plots =
+                                        (self.serial_devices.number_of_plots + 1).clamp(1, 10);
                                 }
                             });
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -683,11 +683,17 @@ impl MyApp {
                             ui.label("Number of plots [#]: ");
 
                             ui.horizontal(|ui| {
+                                if ui.button("<").clicked() {
+                                    self.number_of_plots = (self.number_of_plots - 1).clamp(1, 10);
+                                }
                                 ui.add(egui::DragValue::new(&mut self.number_of_plots)
                                     .clamp_range(1..=10))
                                     .on_hover_text("Select the number of plots to be shown.");
-
+                                if ui.button(">").clicked() {
+                                    self.number_of_plots = (self.number_of_plots + 1).clamp(1, 10);
+                                }
                             });
+
                             ui.end_row();
                             ui.label("Show Sent Commands");
                             ui.add(toggle(&mut self.show_sent_cmds))

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -14,6 +14,7 @@ use crate::{print_to_console, Packet, Print, APP_INFO, PREFS_KEY_SERIAL};
 pub struct SerialDevices {
     pub devices: Vec<Device>,
     pub labels: Vec<Vec<String>>,
+    pub number_of_plots: usize,
 }
 
 impl Default for SerialDevices {
@@ -21,6 +22,7 @@ impl Default for SerialDevices {
         SerialDevices {
             devices: vec![Device::default()],
             labels: vec![vec!["Column 0".to_string()]],
+            number_of_plots: 1,
         }
     }
 }


### PR DESCRIPTION
This adds the ability to display multiple plots, where each column can be toggled individually per plot, potentially closing #82.

Additionally, it adds interactive resize using the separator between the plots and the serial monitor.

The resize code might not be the most pretty implementation, but I was unable to find any example of this in the `egui` examples. Therefore this commit also includes a small refactor of how heights are computed.

One thing left out of this commit, is the ability to save plots of any but the first plot.

