### PR TITLE
fix #95 : improve transfer speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +898,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-text"
+version = "19.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
+dependencies = [
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +944,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cstr"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1050,6 +1081,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1132,18 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "dwrote"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "winapi 0.3.9",
+ "wio",
+]
 
 [[package]]
 name = "ecolor"
@@ -1373,6 +1426,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
+name = "font-kit"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0504fc23a34d36352540ae5eedcec2623c86607a4efe25494ca9641845c5a50"
+dependencies = [
+ "bitflags 2.4.1",
+ "byteorder",
+ "core-foundation",
+ "core-graphics",
+ "core-text",
+ "dirs-next",
+ "dwrote",
+ "float-ord",
+ "freetype",
+ "lazy_static",
+ "libc",
+ "log",
+ "pathfinder_geometry",
+ "pathfinder_simd",
+ "walkdir",
+ "winapi 0.3.9",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1478,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "freetype"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee38378a9e3db1cc693b4f88d166ae375338a0ff75cb8263e1c601d51f35dc6"
+dependencies = [
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+dependencies = [
+ "cmake",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2377,6 +2482,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
+name = "pathfinder_geometry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
+dependencies = [
+ "log",
+ "pathfinder_simd",
+]
+
+[[package]]
+name = "pathfinder_simd"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0444332826c70dc47be74a7c6a5fc44e23a7905ad6858d4162b658320455ef93"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +2961,7 @@ dependencies = [
  "egui-phosphor",
  "egui_extras",
  "egui_plot",
+ "font-kit",
  "hex",
  "image",
  "itertools-num",
@@ -3871,6 +3996,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3936,6 +4070,18 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb6b23999a8b1a997bf47c7bb4d19ad4029c3327bb3386ebe0a5ff584b33c7a"
+dependencies = [
+ "cstr",
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "zbus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,10 @@ regex = "1"
 rfd = "0.12.1"
 safe-transmute = "0.11.2"
 serde = { version = "1.0", features = ["derive"] }
-serialport = { git = "https://github.com/serialport/serialport-rs", features = ["serde"] }
+serialport = { git = "https://github.com/serialport/serialport-rs", features = [
+  "serde",
+] }
+font-kit = { version = "0.12.0", features = ["freetype"] }
 
 [package.metadata.bundle]
 name = "Serial Monitor"

--- a/src/data.rs
+++ b/src/data.rs
@@ -47,7 +47,7 @@ pub struct DataContainer {
     pub time: Vec<u128>,
     pub names: Vec<String>,
     pub absolute_time: Vec<u128>,
-    pub dataset: Vec<Vec<f32>>,
+    pub dataset: Vec<Vec<f64>>,
     pub raw_traffic: Vec<Packet>,
 }
 

--- a/src/gui/components.rs
+++ b/src/gui/components.rs
@@ -1,0 +1,959 @@
+use super::*;
+use eframe::egui::{self, Button, TextEdit, TextStyle};
+use rfd::MessageDialog;
+
+impl MyApp {
+    pub fn serial_settings_ui(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
+        self.need_initialize = false;
+
+        let devices: Vec<String> = if let Ok(read_guard) = self.devices_lock.read() {
+            read_guard.clone()
+        } else {
+            vec![]
+        };
+
+        if !devices.contains(&self.device) {
+            self.device.clear();
+        }
+
+        ui.heading("串口设置");
+        ui.add_space(5.0);
+        ui.horizontal(|ui| {
+            ui.label("Device");
+            ui.add_space(130.0);
+            ui.label("Baud");
+        });
+
+        let old_name = self.device.clone();
+        ui.horizontal(|ui| {
+            let dev_text = self.device.replace("/dev/tty.", "");
+            ui.horizontal(|ui| {
+                ui.set_enabled(!self.connected_to_device);
+                let _response = egui::ComboBox::from_id_source("Device")
+                    .selected_text(dev_text)
+                    .width(RIGHT_PANEL_WIDTH * 0.92 - 155.0)
+                    .show_ui(ui, |ui| {
+                        devices
+                            .into_iter()
+                            // on macOS each device appears as /dev/tty.* and /dev/cu.*
+                            // we only display the /dev/tty.* here
+                            .filter(|dev| !dev.contains("/dev/cu."))
+                            .for_each(|dev| {
+                                // this makes the names shorter in the UI on UNIX and UNIX-like platforms
+                                let dev_text = dev.replace("/dev/tty.", "");
+                                ui.selectable_value(&mut self.device, dev, dev_text);
+                            });
+                    })
+                    .response;
+                // let selected_new_device = response.changed();  //somehow this does not work
+                // if selected_new_device {
+                if old_name != self.device {
+                    if !self.data.time.is_empty() {
+                        self.show_warning_window = WindowFeedback::Waiting;
+                        self.old_device = old_name;
+                    } else {
+                        self.show_warning_window = WindowFeedback::Clear;
+                    }
+                }
+            });
+            match self.show_warning_window {
+                WindowFeedback::None => {}
+                WindowFeedback::Waiting => {
+                    self.show_warning_window = self.clear_warning_window(ctx);
+                }
+                WindowFeedback::Clear => {
+                    // new device selected, check in previously used devices
+                    let mut device_is_already_saved = false;
+                    for (idx, dev) in self.serial_devices.devices.iter().enumerate() {
+                        if dev.name == self.device {
+                            // this is the device!
+                            self.device = dev.name.clone();
+                            self.device_idx = idx;
+                            self.need_initialize = true;
+                            device_is_already_saved = true;
+                        }
+                    }
+                    if !device_is_already_saved {
+                        // create new device in the archive
+                        let mut device = Device::default();
+                        device.name = self.device.clone();
+                        self.serial_devices.devices.push(device);
+                        // self.serial_devices.number_of_plots.push(1);
+                        // self.serial_devices
+                        //     .labels
+                        //     .push(vec!["Column 0".to_string()]);
+                        self.device_idx = self.serial_devices.devices.len() - 1;
+                        save_serial_settings(&self.serial_devices);
+                    }
+                    self.gui_event_tx
+                        .send(GuiEvent::Clear)
+                        .expect("failed to send clear after choosing new device");
+                    // need to clear the data here such that we don't get errors in the gui (plot)
+                    self.data = DataContainer::default();
+                    self.show_warning_window = WindowFeedback::None;
+                }
+                WindowFeedback::Cancel => {
+                    self.device = self.old_device.clone();
+                    self.show_warning_window = WindowFeedback::None;
+                }
+            }
+            egui::ComboBox::from_id_source("Baud Rate")
+                .selected_text(format!(
+                    "{}",
+                    self.serial_devices.devices[self.device_idx].baud_rate
+                ))
+                .width(80.0)
+                .show_ui(ui, |ui| {
+                    BAUD_RATES.iter().for_each(|baud_rate| {
+                        ui.selectable_value(
+                            &mut self.serial_devices.devices[self.device_idx].baud_rate,
+                            *baud_rate,
+                            baud_rate.to_string(),
+                        );
+                    });
+                });
+            let connect_text = if self.connected_to_device {
+                "Disconnect"
+            } else {
+                "Connect"
+            };
+            if ui.button(connect_text).clicked() {
+                if let Ok(mut device) = self.device_lock.write() {
+                    if self.connected_to_device {
+                        device.name.clear();
+                    } else {
+                        device.name = self.serial_devices.devices[self.device_idx].name.clone();
+                        device.baud_rate = self.serial_devices.devices[self.device_idx].baud_rate;
+                    }
+                }
+            }
+        });
+        ui.add_space(5.0);
+        ui.horizontal(|ui| {
+            ui.label("Data Bits");
+            ui.add_space(5.0);
+            ui.label("Parity");
+            ui.add_space(20.0);
+            ui.label("Stop Bits");
+            ui.label("Flow Control");
+            ui.label("Timeout");
+        });
+        ui.horizontal(|ui| {
+            egui::ComboBox::from_id_source("Data Bits")
+                .selected_text(
+                    self.serial_devices.devices[self.device_idx]
+                        .data_bits
+                        .to_string(),
+                )
+                .width(30.0)
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].data_bits,
+                        DataBits::Eight,
+                        DataBits::Eight.to_string(),
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].data_bits,
+                        DataBits::Seven,
+                        DataBits::Seven.to_string(),
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].data_bits,
+                        DataBits::Six,
+                        DataBits::Six.to_string(),
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].data_bits,
+                        DataBits::Five,
+                        DataBits::Five.to_string(),
+                    );
+                });
+            egui::ComboBox::from_id_source("Parity")
+                .selected_text(
+                    self.serial_devices.devices[self.device_idx]
+                        .parity
+                        .to_string(),
+                )
+                .width(30.0)
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].parity,
+                        Parity::None,
+                        Parity::None.to_string(),
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].parity,
+                        Parity::Odd,
+                        Parity::Odd.to_string(),
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].parity,
+                        Parity::Even,
+                        Parity::Even.to_string(),
+                    );
+                });
+            egui::ComboBox::from_id_source("Stop Bits")
+                .selected_text(
+                    self.serial_devices.devices[self.device_idx]
+                        .stop_bits
+                        .to_string(),
+                )
+                .width(30.0)
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].stop_bits,
+                        StopBits::One,
+                        StopBits::One.to_string(),
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].stop_bits,
+                        StopBits::Two,
+                        StopBits::Two.to_string(),
+                    );
+                });
+            egui::ComboBox::from_id_source("Flow Control")
+                .selected_text(
+                    self.serial_devices.devices[self.device_idx]
+                        .flow_control
+                        .to_string(),
+                )
+                .width(75.0)
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].flow_control,
+                        FlowControl::None,
+                        FlowControl::None.to_string(),
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].flow_control,
+                        FlowControl::Hardware,
+                        FlowControl::Hardware.to_string(),
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].flow_control,
+                        FlowControl::Software,
+                        FlowControl::Software.to_string(),
+                    );
+                });
+            egui::ComboBox::from_id_source("Timeout")
+                .selected_text(
+                    self.serial_devices.devices[self.device_idx]
+                        .timeout
+                        .as_millis()
+                        .to_string(),
+                )
+                .width(55.0)
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].timeout,
+                        Duration::from_millis(0),
+                        "0",
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].timeout,
+                        Duration::from_millis(10),
+                        "10",
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].timeout,
+                        Duration::from_millis(100),
+                        "100",
+                    );
+                    ui.selectable_value(
+                        &mut self.serial_devices.devices[self.device_idx].timeout,
+                        Duration::from_millis(1000),
+                        "1000",
+                    );
+                });
+        });
+    }
+
+    pub fn plot_settings_ui(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
+        ui.heading("画图设置");
+        ui.add_space(5.0);
+        egui::Grid::new("upper")
+            .num_columns(2)
+            .spacing(Vec2 { x: 10.0, y: 10.0 })
+            .striped(true)
+            .show(ui, |ui| {
+                if ui
+                    .button(egui::RichText::new(format!(
+                        "{} Save CSV",
+                        egui_phosphor::regular::FLOPPY_DISK
+                    )))
+                    .on_hover_text("Save Plot Data to CSV.")
+                    .clicked()
+                    || ui.input_mut(|i| i.consume_shortcut(&SAVE_FILE_SHORTCUT))
+                {
+                    if let Some(path) = rfd::FileDialog::new().save_file() {
+                        self.picked_path = path;
+                        self.picked_path.set_extension("csv");
+                        if let Err(e) = self.gui_event_tx.send(GuiEvent::SaveCSV(FileOptions {
+                            file_path: self.picked_path.clone(),
+                            save_absolute_time: self.gui_conf.save_absolute_time,
+                            save_raw_traffic: self.save_raw,
+                        })) {
+                            print_to_console(
+                                &self.print_lock,
+                                Print::Error(format!("save_tx thread send failed: {:?}", e)),
+                            );
+                        }
+                    }
+                };
+
+                if ui
+                    .button(egui::RichText::new(format!(
+                        "{} Save Plot",
+                        egui_phosphor::regular::FLOPPY_DISK
+                    )))
+                    .on_hover_text("Save an image of the Plot.")
+                    .clicked()
+                    || ui.input_mut(|i| i.consume_shortcut(&SAVE_PLOT_SHORTCUT))
+                {
+                    ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot);
+                }
+                ui.end_row();
+                if ui
+                    .button(egui::RichText::new(format!(
+                        "{} Clear Data",
+                        egui_phosphor::regular::X
+                    )))
+                    .on_hover_text("Clear Data from Plot.")
+                    .clicked()
+                    || ui.input_mut(|i| i.consume_shortcut(&CLEAR_PLOT_SHORTCUT))
+                {
+                    print_to_console(
+                        &self.print_lock,
+                        Print::Ok("Cleared recorded Data".to_string()),
+                    );
+                    if let Err(err) = self.gui_event_tx.send(GuiEvent::Clear) {
+                        print_to_console(
+                            &self.print_lock,
+                            Print::Error(format!("clear_tx thread send failed: {:?}", err)),
+                        );
+                    }
+                    // need to clear the data here in order to prevent errors in the gui (plot)
+                    self.data = DataContainer::default();
+                    self.gui_event_tx
+                        .send(GuiEvent::SetNames(
+                            self.gui_conf.plot_options.labels.clone(),
+                        ))
+                        .expect("Failed to send names");
+                }
+                ui.end_row();
+                ui.label("Save Raw Traffic");
+                ui.add(toggle(&mut self.save_raw))
+                    .on_hover_text("Save second CSV containing raw traffic.")
+                    .changed();
+                ui.end_row();
+                ui.label("Save Absolute Time");
+                ui.add(toggle(&mut self.gui_conf.save_absolute_time))
+                    .on_hover_text("Save absolute time in CSV.");
+                ui.end_row();
+            });
+        ui.add_space(25.0);
+        global_dark_light_mode_buttons(ui);
+        ui.add_space(25.0);
+        self.gui_conf.dark_mode = ui.visuals() == &Visuals::dark();
+        ui.horizontal(|ui| {
+            if ui.button("Clear Device History").clicked() {
+                self.serial_devices = SerialDevices::default();
+                self.device.clear();
+                self.device_idx = 0;
+                clear_serial_settings();
+            }
+        });
+    }
+
+    pub fn debug_console_ui(&mut self, ui: &mut egui::Ui) {
+        if let Ok(read_guard) = self.print_lock.read() {
+            self.console = read_guard.clone();
+        }
+        let num_rows = self.console.len();
+        let row_height = ui.text_style_height(&egui::TextStyle::Body);
+        ui.label("Debug Info:");
+        ui.add_space(10.0);
+        egui::ScrollArea::vertical()
+            .id_source("console_scroll_area")
+            .auto_shrink([false; 2])
+            .stick_to_bottom(true)
+            .max_height(row_height * 15.5)
+            .show_rows(ui, row_height, num_rows, |ui, _row_range| {
+                let content: String = self
+                    .console
+                    .iter()
+                    .flat_map(|row| row.scroll_area_message(&self.gui_conf))
+                    .map(|msg| msg.label + msg.content.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                // we need to add it as one multiline object, such that we can select and copy
+                // text over multiple lines
+                ui.add(
+                    egui::TextEdit::multiline(&mut content.as_str())
+                        .font(DEFAULT_FONT_ID) // for cursor height
+                        .lock_focus(true), // TODO: add a layouter to highlight the labels
+                );
+            });
+    }
+
+    pub fn plots_ui(&mut self, ui: &mut egui::Ui) -> egui::InnerResponse<()> {
+        let border = 10.0;
+        let width = ui.available_size().x - 2.0 * border;
+        let height = if self.active_tab.is_none() {
+            ui.available_height() - 18.0
+        } else {
+            ui.available_height() * self.plot_serial_display_ratio
+        };
+        let plots_height = height;
+        // need to subtract 12.0, this seems to be the height of the separator of two adjacent plots
+        let plot_height = plots_height / (self.gui_conf.plot_options.number_of_plots as f32) - 12.0;
+
+        if let Ok(read_guard) = self.data_lock.read() {
+            self.data = read_guard.clone();
+        }
+
+        let mut graphs: Vec<Vec<PlotPoint>> = vec![vec![]; self.data.dataset.len()];
+        let window = self.data.dataset[0]
+            .len()
+            .saturating_sub(self.gui_conf.plot_options.plotting_range);
+
+        for (i, time) in self.data.time[window..].iter().enumerate() {
+            let x = if self.gui_conf.plot_options.time_x_axis {
+                *time as f64 / 1000.0
+            } else {
+                (i + 1) as f64
+            };
+            for (graph, data) in graphs.iter_mut().zip(&self.data.dataset) {
+                if self.data.time.len() == data.len() {
+                    if let Some(y) = data.get(i + window) {
+                        graph.push(PlotPoint { x, y: *y as f64 });
+                    }
+                }
+            }
+        }
+
+        // let t_fmt = |x, _n, _range: &RangeInclusive<f64>| format!("{:4.2} s", x);
+
+        ui.vertical_centered_justified(|ui| {
+            for graph_idx in 0..self.gui_conf.plot_options.number_of_plots {
+                if graph_idx != 0 {
+                    ui.separator();
+                }
+
+                let signal_plot = Plot::new(format!("data-{graph_idx}"))
+                    .height(plot_height)
+                    .width(width)
+                    .auto_bounds_x()
+                    .auto_bounds_y()
+                    .legend(Legend::default())
+                    .x_grid_spacer(log_grid_spacer(10))
+                    .y_grid_spacer(log_grid_spacer(10));
+
+                // .x_axis_formatter(t_fmt);
+
+                let plot_inner = signal_plot.show(ui, |signal_plot_ui| {
+                    for (i, graph) in graphs.iter().enumerate() {
+                        // this check needs to be here for when we change devices (not very elegant)
+                        if i < self.gui_conf.plot_options.labels.len() {
+                            signal_plot_ui.line(
+                                Line::new(PlotPoints::Owned(graph.to_vec()))
+                                    .name(&self.gui_conf.plot_options.labels[i]),
+                            );
+                        }
+                    }
+                });
+
+                self.plot_location = Some(plot_inner.response.rect);
+            }
+        })
+    }
+
+    pub fn serial_raw_traffic_ui(&mut self, ui: &mut egui::Ui) {
+        let border = 10.0;
+
+        let spacing = 5.0;
+        let serial_height = ui.available_size().y - border * 2.0;
+
+        let num_rows = self.data.raw_traffic.len();
+        let row_height = ui.text_style_height(&egui::TextStyle::Body);
+
+        let color = if self.gui_conf.dark_mode {
+            egui::Color32::WHITE
+        } else {
+            egui::Color32::BLACK
+        };
+        ui.horizontal_top(|ui| {
+            ui.vertical(|ui| {
+                ui.heading("Options");
+                ui.add_space(10.0);
+                egui::ScrollArea::vertical()
+                    .id_source("raw traffic options scroll")
+                    .auto_shrink([false; 2])
+                    .max_width(150.0)
+                    .show(ui, |ui| {
+                        if ui
+                            .selectable_label(self.gui_conf.raw_traffic_options.enable, "Enable")
+                            .clicked()
+                        {
+                            self.gui_conf.raw_traffic_options.enable =
+                                !self.gui_conf.raw_traffic_options.enable;
+                            self.gui_event_tx
+                                .send(GuiEvent::SetRawTrafficOptions(
+                                    self.gui_conf.raw_traffic_options.clone(),
+                                ))
+                                .expect("Failed to update raw traffic options")
+                        };
+
+                        if ui
+                            .selectable_label(
+                                self.gui_conf.raw_traffic_options.show_sent_cmds,
+                                "Show Sent Commands",
+                            )
+                            .on_hover_text("Show sent commands in console.")
+                            .clicked()
+                        {
+                            self.gui_conf.raw_traffic_options.show_sent_cmds =
+                                !self.gui_conf.raw_traffic_options.show_sent_cmds
+                        };
+
+                        if ui
+                            .selectable_label(
+                                self.gui_conf.raw_traffic_options.show_timestamps,
+                                "Show Timestamp",
+                            )
+                            .on_hover_text("Show timestamp in console.")
+                            .clicked()
+                        {
+                            self.gui_conf.raw_traffic_options.show_timestamps =
+                                !self.gui_conf.raw_traffic_options.show_timestamps
+                        };
+                        ui.add_space(10.0);
+                        ui.label("EOL character:");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut self.gui_conf.raw_traffic_options.eol)
+                                .desired_width(80.0),
+                        )
+                        .on_hover_text("Configure your EOL character for sent commands..");
+
+                        ui.add_space(10.0);
+
+                        ui.label("Max Recorded Len:");
+                        if ui
+                            .add(egui::DragValue::new(
+                                &mut self.gui_conf.raw_traffic_options.max_len,
+                            ))
+                            .on_hover_text("Select the number of raw traffic to be recorded.")
+                            .changed()
+                        {
+                            self.gui_event_tx
+                                .send(GuiEvent::SetRawTrafficOptions(
+                                    self.gui_conf.raw_traffic_options.clone(),
+                                ))
+                                .expect("Failed to update raw traffic options")
+                        }
+                    });
+            });
+
+            ui.separator();
+
+            let width = ui.available_size().x - 2.0 * border;
+            ui.vertical_centered_justified(|ui| {
+                egui::ScrollArea::vertical()
+                    .id_source("serial_output")
+                    .auto_shrink([false; 2])
+                    .stick_to_bottom(true)
+                    .enable_scrolling(true)
+                    .max_height(serial_height - 2.0 * spacing)
+                    .min_scrolled_height(serial_height - spacing)
+                    .max_width(width)
+                    .show_rows(ui, row_height, num_rows, |ui, row_range| {
+                        let content: String = row_range
+                            .into_iter()
+                            .flat_map(|i| {
+                                if self.data.raw_traffic.is_empty() {
+                                    None
+                                } else {
+                                    self.console_text(&self.data.raw_traffic[i])
+                                }
+                            })
+                            .collect();
+                        ui.add(
+                            egui::TextEdit::multiline(&mut content.as_str())
+                                .font(DEFAULT_FONT_ID) // for cursor height
+                                .lock_focus(true)
+                                .text_color(color)
+                                .desired_width(width),
+                        );
+                    });
+                ui.add_space(spacing / 2.0);
+                ui.horizontal(|ui| {
+                    let cmd_line = ui.add(
+                        egui::TextEdit::singleline(&mut self.command)
+                            .desired_width(width - 50.0)
+                            .lock_focus(true)
+                            .code_editor(),
+                    );
+                    let cmd_has_lost_focus = cmd_line.lost_focus();
+                    let key_pressed = ui.input(|i| i.key_pressed(egui::Key::Enter));
+                    if (key_pressed && cmd_has_lost_focus) || ui.button("Send").clicked() {
+                        // send command
+                        let command = self
+                            .command
+                            .clone()
+                            .replace("\\r", "\r")
+                            .replace("\\n", "\n");
+                        self.history.push(command.clone());
+                        self.index = self.history.len() - 1;
+                        let eol = self
+                            .gui_conf
+                            .raw_traffic_options
+                            .eol
+                            .replace("\\r", "\r")
+                            .replace("\\n", "\n");
+                        if let Err(err) = self.send_tx.send(command.clone() + &eol) {
+                            print_to_console(
+                                &self.print_lock,
+                                Print::Error(format!("send_tx thread send failed: {:?}", err)),
+                            );
+                        }
+                        // stay in focus!
+                        cmd_line.request_focus();
+                    }
+                });
+
+                if ui.input(|i| i.key_pressed(egui::Key::ArrowUp)) {
+                    self.index = self.index.saturating_sub(1);
+                    if !self.history.is_empty() {
+                        self.command = self.history[self.index].clone();
+                    }
+                }
+                if ui.input(|i| i.key_pressed(egui::Key::ArrowDown)) {
+                    self.index = std::cmp::min(self.index + 1, self.history.len() - 1);
+                    if !self.history.is_empty() {
+                        self.command = self.history[self.index].clone();
+                    }
+                }
+            });
+        });
+    }
+
+    pub fn plot_options_ui(&mut self, ui: &mut egui::Ui) {
+        let spacing = 10.0;
+        let linespread = 5.0;
+        ui.horizontal_centered(|ui| {
+            ui.vertical(|ui| {
+                ui.heading("Plot Options");
+                ui.add_space(linespread);
+                egui::ScrollArea::vertical()
+                    .max_width(200.0)
+                    .auto_shrink([false; 2])
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("Buffer size [#]: ");
+                            ui.add_space(spacing);
+
+                            if ui
+                                .add(
+                                    egui::DragValue::new(
+                                        &mut self.gui_conf.plot_options.buffer_size,
+                                    )
+                                    .update_while_editing(false),
+                                )
+                                .on_hover_text("Set the max recorded buffer size.")
+                                .changed()
+                            {
+                                self.gui_event_tx
+                                    .send(GuiEvent::SetBufferSize(
+                                        self.gui_conf.plot_options.buffer_size,
+                                    ))
+                                    .expect("Failed to send buffer size");
+                            };
+                        });
+
+                        ui.add_space(linespread);
+
+                        ui.horizontal(|ui| {
+                            ui.label("Plotting range [#]: ");
+                            ui.add_space(spacing);
+
+                            let window_fmt = |val: f64, _range: RangeInclusive<usize>| {
+                                if val != usize::MAX as f64 {
+                                    val.to_string()
+                                } else {
+                                    "∞".to_string()
+                                }
+                            };
+
+                            ui.add(
+                        egui::DragValue::new(&mut self.gui_conf.plot_options.plotting_range)
+                            .custom_formatter(window_fmt),
+                    )
+                    .on_hover_text(
+                        "Select a window of the last datapoints to be displayed in the plot.",
+                    );
+                            if ui
+                                .button("Full Dataset")
+                                .on_hover_text("Show the full dataset.")
+                                .clicked()
+                            {
+                                self.gui_conf.plot_options.plotting_range = usize::MAX;
+                            }
+                        });
+
+                        ui.add_space(linespread);
+
+                        ui.horizontal(|ui| {
+                            ui.label("Number of plots [#]: ");
+                            ui.add_space(spacing);
+
+                            if ui
+                                .button(egui::RichText::new(
+                                    egui_phosphor::regular::ARROW_FAT_LEFT.to_string(),
+                                ))
+                                .clicked()
+                            {
+                                self.gui_conf.plot_options.number_of_plots =
+                                    (self.gui_conf.plot_options.number_of_plots - 1).clamp(1, 10);
+                            }
+                            ui.add(
+                                egui::DragValue::new(
+                                    &mut self.gui_conf.plot_options.number_of_plots,
+                                )
+                                .clamp_range(1..=10),
+                            )
+                            .on_hover_text("Select the number of plots to be shown.");
+                            if ui
+                                .button(egui::RichText::new(
+                                    egui_phosphor::regular::ARROW_FAT_RIGHT.to_string(),
+                                ))
+                                .clicked()
+                            {
+                                self.gui_conf.plot_options.number_of_plots =
+                                    (self.gui_conf.plot_options.number_of_plots + 1).clamp(1, 10);
+                            }
+                        });
+
+                        ui.add_space(linespread);
+
+                        if ui
+                            .selectable_label(
+                                self.gui_conf.plot_options.time_x_axis,
+                                "Time as X Axis",
+                            )
+                            .clicked()
+                        {
+                            self.gui_conf.plot_options.time_x_axis =
+                                !self.gui_conf.plot_options.time_x_axis;
+                        }
+                    });
+            });
+            ui.separator();
+            ui.vertical(|ui| {
+                if ui.button("Reset Labels").clicked() {
+                    self.gui_conf.plot_options.labels = self.data.names.clone();
+                }
+                ui.add_space(linespread);
+                if self.data.names.len() == 1 {
+                    ui.label("Detected 1 Dataset:");
+                } else {
+                    ui.label(format!("Detected {} Datasets:", self.data.names.len()));
+                }
+                ui.add_space(5.0);
+                for i in 0..self.data.names.len().min(10) {
+                    // if init, set names to what has been stored in the device last time
+                    if self.need_initialize {
+                        self.gui_event_tx
+                            .send(GuiEvent::SetNames(
+                                self.gui_conf.plot_options.labels.clone(),
+                            ))
+                            .expect("Failed to send names");
+                        self.need_initialize = false;
+                    }
+                    if self.gui_conf.plot_options.labels.len() <= i {
+                        self.gui_conf
+                            .plot_options
+                            .labels
+                            .push(self.data.names[i].clone());
+                        // break;
+                    }
+
+                    if ui
+                        .add(
+                            egui::TextEdit::singleline(&mut self.gui_conf.plot_options.labels[i])
+                                .desired_width(150.0),
+                        )
+                        .on_hover_text("Use custom names for your Datasets.")
+                        .changed()
+                    {
+                        self.gui_event_tx
+                            .send(GuiEvent::SetNames(
+                                self.gui_conf.plot_options.labels.clone(),
+                            ))
+                            .expect("Failed to send names");
+                    };
+                }
+                if self.data.names.len() > 10 {
+                    ui.label("Only renaming up to 10 Datasets is currently supported.");
+                }
+            })
+        });
+    }
+
+    pub fn record_gui(&mut self, ui: &mut egui::Ui) {
+        const LINESPREAD: f32 = 10.0;
+        const SPACE: f32 = 15.0;
+        let mut input_path = self
+            .gui_conf
+            .record_options
+            .record_path
+            .to_str()
+            .unwrap_or("")
+            .to_owned();
+
+        ui.horizontal(|ui| {
+            ui.heading("Record Options");
+            ui.add_space(2.0 * SPACE);
+
+            ui.style_mut().text_styles = [(
+                TextStyle::Button,
+                FontId::new(16.0, FontFamily::Proportional),
+            )]
+            .into();
+
+            if ui
+                .selectable_label(self.gui_conf.record_options.enable, "Start Record")
+                .clicked()
+            {
+                let mut ready = true;
+                self.gui_conf
+                    .record_options
+                    .record_path
+                    .set_extension("csv");
+                if !self.gui_conf.record_options.enable
+                    && self.gui_conf.record_options.record_path.exists()
+                {
+                    ready = false;
+                    let result = MessageDialog::new()
+                        .set_title("Overwrite confirm")
+                        .set_description(format!(
+                            "File {} exists. Do you want to overwrite it?",
+                            self.gui_conf
+                                .record_options
+                                .record_path
+                                .to_str()
+                                .unwrap_or_default()
+                        ))
+                        .set_buttons(rfd::MessageButtons::YesNo)
+                        .show();
+                    match result {
+                        rfd::MessageDialogResult::Yes => ready = true,
+                        rfd::MessageDialogResult::No => ready = false,
+                        _ => (),
+                    }
+                }
+                if ready {
+                    self.gui_conf.record_options.enable = !self.gui_conf.record_options.enable;
+                    self.record_options_tx
+                        .send(self.gui_conf.record_options.clone())
+                        .expect("Failed to send record options");
+                }
+            }
+
+            ui.reset_style();
+        });
+        ui.add_space(LINESPREAD);
+        ui.horizontal(|ui| {
+            if ui
+                .add(
+                    egui::TextEdit::singleline(&mut input_path)
+                        .desired_width(ui.available_width() * 0.8)
+                        .hint_text("Enter file name or browse"),
+                )
+                .changed()
+            {
+                self.gui_conf.record_options.record_path = PathBuf::from(input_path);
+            };
+
+            if ui.button("Browse").clicked() {
+                if let Some(path) = rfd::FileDialog::new().save_file() {
+                    self.gui_conf.record_options.record_path = path;
+                    self.gui_conf
+                        .record_options
+                        .record_path
+                        .set_extension("csv");
+                }
+            }
+        });
+    }
+
+    pub fn commands_gui(&mut self, ui: &mut egui::Ui) {
+        const LINESPREAD: f32 = 10.0;
+
+        ui.heading("Commands");
+        ui.add_space(LINESPREAD);
+        egui::ScrollArea::vertical()
+            .id_source("commands_scroll_area")
+            .auto_shrink([false; 2])
+            .max_width(ui.available_width())
+            .max_height(ui.available_height())
+            .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.vertical(|ui| {
+                        for cmd in &mut self.gui_conf.commands {
+                            let name_resp = ui.add(
+                                TextEdit::singleline(&mut cmd.name)
+                                    .frame(cmd.editing)
+                                    .desired_width(0.0)
+                                    .clip_text(false),
+                            );
+                            if name_resp.clicked() || name_resp.has_focus() {
+                                cmd.editing = true
+                            } else {
+                                cmd.editing = false
+                            }
+                        }
+                    });
+                    ui.add_space(5.0);
+                    ui.vertical(|ui| {
+                        self.gui_conf.commands.retain_mut(|cmd| {
+                            ui.horizontal(|ui| {
+                                ui.add(
+                                    TextEdit::singleline(&mut cmd.cmd)
+                                        .code_editor()
+                                        .lock_focus(false)
+                                        .clip_text(true)
+                                        .desired_width(ui.available_width() - 90.0),
+                                );
+                                let send_cmd =
+                                    cmd.cmd.clone().replace("\\r", "\r").replace("\\n", "\n");
+                                if ui.button("Send").clicked() {
+                                    if let Err(err) = self.send_tx.send(send_cmd) {
+                                        print_to_console(
+                                            &self.print_lock,
+                                            Print::Error(format!(
+                                                "send_tx thread send failed: {:?}",
+                                                err
+                                            )),
+                                        );
+                                    }
+                                }
+                                !ui.button("Del").clicked()
+                            })
+                            .inner
+                        })
+                    })
+                });
+                ui.add_space(LINESPREAD);
+                if ui
+                    .add_sized([ui.available_width(), 20.0], Button::new("New Command"))
+                    .clicked()
+                {
+                    self.gui_conf.commands.push(Command {
+                        name: format!("Command {}", self.gui_conf.commands.len() + 1),
+                        cmd: "".to_owned(),
+                        editing: false,
+                    })
+                };
+            });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(vec_into_raw_parts)]
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 // hide console window on Windows in release
 extern crate core;
@@ -8,23 +9,29 @@ extern crate serde;
 use std::cmp::max;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{mpsc, Arc, RwLock};
-use std::thread;
 use std::time::Duration;
+use std::{fs, thread};
 
-use eframe::egui::{vec2, ViewportBuilder, Visuals};
+use eframe::egui::{vec2, FontData, ViewportBuilder, Visuals};
 use eframe::{egui, icon_data};
+use font_kit::family_name::FamilyName;
+use font_kit::properties::Properties;
+use gui::{PlotOptions, RawTrafficOptions};
 use preferences::AppInfo;
 
 use crate::data::{DataContainer, Packet};
 use crate::gui::{load_gui_settings, print_to_console, MyApp, Print, RIGHT_PANEL_WIDTH};
 use crate::io::{save_to_csv, FileOptions};
+use crate::record::{record_thread, RecordData, RecordOptions};
 use crate::serial::{load_serial_settings, serial_thread, Device};
 
 mod data;
 mod gui;
 mod io;
+mod record;
 mod serial;
 mod toggle;
+mod utils;
 
 const APP_INFO: AppInfo = AppInfo {
     name: "Serial Monitor",
@@ -33,7 +40,15 @@ const APP_INFO: AppInfo = AppInfo {
 const PREFS_KEY: &str = "config/gui";
 const PREFS_KEY_SERIAL: &str = "config/serial_devices";
 
-fn split(payload: &str) -> Vec<f32> {
+enum GuiEvent {
+    SetRawTrafficOptions(RawTrafficOptions),
+    SetBufferSize(usize),
+    SetNames(Vec<String>),
+    SaveCSV(FileOptions),
+    Clear,
+}
+
+fn split(payload: &str) -> Vec<f64> {
     let mut split_data: Vec<&str> = vec![];
     for s in payload.split(':') {
         split_data.extend(s.split(','));
@@ -41,7 +56,7 @@ fn split(payload: &str) -> Vec<f32> {
     split_data
         .iter()
         .map(|x| x.trim())
-        .flat_map(|x| x.parse::<f32>())
+        .flat_map(|x| x.parse::<f64>())
         .collect()
 }
 
@@ -49,48 +64,73 @@ fn main_thread(
     data_lock: Arc<RwLock<DataContainer>>,
     print_lock: Arc<RwLock<Vec<Print>>>,
     raw_data_rx: Receiver<Packet>,
-    names_rx: Receiver<Vec<String>>,
-    save_rx: Receiver<FileOptions>,
-    clear_rx: Receiver<bool>,
+    gui_event_rx: Receiver<GuiEvent>,
+    record_data_tx: Sender<RecordData>,
 ) {
     // reads data from mutex, samples and saves if needed
-    let mut data = DataContainer::default();
+    // let mut data = DataContainer::default();
+    let mut raw_traffic_options = RawTrafficOptions::default();
     let mut failed_format_counter = 0;
+    let mut buffer_size = PlotOptions::default().buffer_size;
     loop {
-        if let Ok(cl) = clear_rx.recv_timeout(Duration::from_millis(1)) {
-            if cl {
-                data = DataContainer::default();
-                failed_format_counter = 0;
+        if let Ok(event) = gui_event_rx.try_recv() {
+            match event {
+                GuiEvent::SetRawTrafficOptions(opt) => raw_traffic_options = opt,
+                GuiEvent::SetNames(names) => {
+                    if let Ok(mut write_guard) = data_lock.write() {
+                        write_guard.names = names;
+                    }
+                }
+                GuiEvent::SaveCSV(csv_options) => {
+                    if let Ok(read_guard) = data_lock.read() {
+                        match save_to_csv(&read_guard, &csv_options) {
+                            Ok(_) => {
+                                print_to_console(
+                                    &print_lock,
+                                    Print::Ok(format!(
+                                        "saved data file to {:?} ",
+                                        csv_options.file_path
+                                    )),
+                                );
+                            }
+                            Err(e) => {
+                                print_to_console(
+                                    &print_lock,
+                                    Print::Error(format!(
+                                        "failed to save file to {:?}: {:?}",
+                                        csv_options.file_path, e
+                                    )),
+                                );
+                            }
+                        }
+                    }
+                }
+                GuiEvent::Clear => {
+                    if let Ok(mut write_guard) = data_lock.write() {
+                        *write_guard = DataContainer::default();
+                        failed_format_counter = 0;
+                    }
+                }
+                GuiEvent::SetBufferSize(s) => buffer_size = s,
             }
-        }
-
-        if let Ok(names) = names_rx.recv_timeout(Duration::from_millis(1)) {
-            data.names = names;
         }
 
         if let Ok(packet) = raw_data_rx.recv_timeout(Duration::from_millis(1)) {
             if !packet.payload.is_empty() {
-                data.raw_traffic.push(packet.clone());
-                let split_data = split(&packet.payload);
-                if data.dataset.is_empty() || failed_format_counter > 10 {
-                    // resetting dataset
-                    data.dataset = vec![vec![]; max(split_data.len(), 1)];
-                    if data.names.len() != split_data.len() {
-                        data.names = (0..max(split_data.len(), 1))
-                            .map(|i| format!("Column {i}"))
-                            .collect();
+                if let Ok(write_guard) = data_lock.write() {
+                    let mut data = write_guard;
+                    if raw_traffic_options.enable {
+                        data.raw_traffic.push(packet.clone());
+                        let raw_traffic_len = data.raw_traffic.len();
+                        data.raw_traffic = data
+                            .raw_traffic
+                            .split_off(raw_traffic_len.saturating_sub(raw_traffic_options.max_len));
                     }
-                    failed_format_counter = 0;
-                    // println!("resetting dataset. split length = {}, length data.dataset = {}", split_data.len(), data.dataset.len());
-                } else if split_data.len() == data.dataset.len() {
-                    // appending data
-                    for (i, set) in data.dataset.iter_mut().enumerate() {
-                        set.push(split_data[i]);
-                        failed_format_counter = 0;
-                    }
-                    data.time.push(packet.relative_time);
-                    data.absolute_time.push(packet.absolute_time);
-                    if data.time.len() != data.dataset[0].len() {
+                    let split_data = split(&packet.payload);
+                    if data.dataset.is_empty()
+                        || failed_format_counter > 10
+                        || data.dataset[0].len() != data.time.len()
+                    {
                         // resetting dataset
                         data.time = vec![];
                         data.dataset = vec![vec![]; max(split_data.len(), 1)];
@@ -99,35 +139,40 @@ fn main_thread(
                                 .map(|i| format!("Column {i}"))
                                 .collect();
                         }
+                        failed_format_counter = 0;
+                        // println!("resetting dataset. split length = {}, length data.dataset = {}", split_data.len(), data.dataset.len());
+                    } else if split_data.len() == data.dataset.len() {
+                        record_data_tx
+                            .send(RecordData {
+                                time: packet.absolute_time,
+                                datas: split_data.clone(),
+                            })
+                            .unwrap_or_default();
+                        // appending data
+                        for (i, set) in data.dataset.iter_mut().enumerate() {
+                            set.push(split_data[i]);
+                            failed_format_counter = 0;
+                            while set.len() > buffer_size {
+                                set.remove(0);
+                            }
+                        }
+                        data.time.push(packet.relative_time);
+                        while data.time.len() > buffer_size {
+                            data.time.remove(0);
+                        }
+                        data.absolute_time.push(packet.absolute_time);
+                        while data.absolute_time.len() > buffer_size {
+                            data.absolute_time.remove(0);
+                        }
+                    } else {
+                        // not same length
+                        failed_format_counter += 1;
+                        // println!("not same length in main! length split_data = {}, length data.dataset = {}", split_data.len(), data.dataset.len())
                     }
-                } else {
-                    // not same length
-                    failed_format_counter += 1;
-                    // println!("not same length in main! length split_data = {}, length data.dataset = {}", split_data.len(), data.dataset.len())
                 }
-                if let Ok(mut write_guard) = data_lock.write() {
-                    *write_guard = data.clone();
-                }
-            }
-        }
-
-        if let Ok(csv_options) = save_rx.recv_timeout(Duration::from_millis(1)) {
-            match save_to_csv(&data, &csv_options) {
-                Ok(_) => {
-                    print_to_console(
-                        &print_lock,
-                        Print::Ok(format!("saved data file to {:?} ", csv_options.file_path)),
-                    );
-                }
-                Err(e) => {
-                    print_to_console(
-                        &print_lock,
-                        Print::Error(format!(
-                            "failed to save file to {:?}: {:?}",
-                            csv_options.file_path, e
-                        )),
-                    );
-                }
+                // if let Ok(mut write_guard) = data_lock.write() {
+                //     *write_guard = data.clone();
+                // }
             }
         }
 
@@ -145,11 +190,11 @@ fn main() {
     let print_lock = Arc::new(RwLock::new(vec![Print::Empty]));
     let connected_lock = Arc::new(RwLock::new(false));
 
-    let (save_tx, save_rx): (Sender<FileOptions>, Receiver<FileOptions>) = mpsc::channel();
     let (send_tx, send_rx): (Sender<String>, Receiver<String>) = mpsc::channel();
-    let (clear_tx, clear_rx): (Sender<bool>, Receiver<bool>) = mpsc::channel();
-    let (names_tx, names_rx): (Sender<Vec<String>>, Receiver<Vec<String>>) = mpsc::channel();
     let (raw_data_tx, raw_data_rx): (Sender<Packet>, Receiver<Packet>) = mpsc::channel();
+    let (gui_event_tx, gui_event_rx) = mpsc::channel::<GuiEvent>();
+    let (record_options_tx, record_options_rx) = mpsc::channel::<RecordOptions>();
+    let (record_data_tx, record_data_rx) = mpsc::channel::<RecordData>();
 
     let serial_device_lock = device_lock.clone();
     let serial_devices_lock = devices_lock.clone();
@@ -168,6 +213,18 @@ fn main() {
         );
     });
 
+    let record_data_lock = data_lock.clone();
+    let record_print_lock = print_lock.clone();
+
+    let _record_thread_handler = thread::spawn(|| {
+        record_thread(
+            record_data_lock,
+            record_print_lock,
+            record_options_rx,
+            record_data_rx,
+        )
+    });
+
     let main_data_lock = data_lock.clone();
     let main_print_lock = print_lock.clone();
 
@@ -177,9 +234,8 @@ fn main() {
             main_data_lock,
             main_print_lock,
             raw_data_rx,
-            names_rx,
-            save_rx,
-            clear_rx,
+            gui_event_rx,
+            record_data_tx,
         );
     });
 
@@ -206,9 +262,32 @@ fn main() {
         options,
         Box::new(|_cc| {
             let mut fonts = egui::FontDefinitions::default();
+            let handle = font_kit::source::SystemSource::new()
+                .select_best_match(&[FamilyName::SansSerif], &Properties::new())
+                .unwrap();
+            let buf: Vec<u8> = match handle {
+                font_kit::handle::Handle::Memory { bytes, .. } => bytes.to_vec(),
+                font_kit::handle::Handle::Path { path, .. } => fs::read(path).unwrap(),
+            };
+
+            const FONT_SYSTEM_SANS_SERIF: &'static str = "System Sans Serif";
+
             egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
+            fonts
+                .font_data
+                .insert(FONT_SYSTEM_SANS_SERIF.to_owned(), FontData::from_owned(buf));
+
+            if let Some(vec) = fonts.families.get_mut(&egui::FontFamily::Proportional) {
+                vec.push(FONT_SYSTEM_SANS_SERIF.to_owned());
+            }
+
+            if let Some(vec) = fonts.families.get_mut(&egui::FontFamily::Monospace) {
+                vec.push(FONT_SYSTEM_SANS_SERIF.to_owned());
+            }
+
             _cc.egui_ctx.set_fonts(fonts);
-            _cc.egui_ctx.set_visuals(Visuals::dark());
+            _cc.egui_ctx.set_visuals(Visuals::light());
+
             Box::new(MyApp::new(
                 gui_print_lock,
                 gui_data_lock,
@@ -217,10 +296,9 @@ fn main() {
                 saved_serial_device_configs,
                 gui_connected_lock,
                 gui_settings,
-                names_tx,
-                save_tx,
                 send_tx,
-                clear_tx,
+                gui_event_tx,
+                record_options_tx,
             ))
         }),
     ) {

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,0 +1,120 @@
+use csv::Writer;
+use serde::{Deserialize, Serialize};
+
+use crate::data::DataContainer;
+use crate::gui::{print_to_console, Print};
+use std::fs::{self, File};
+use std::path::PathBuf;
+use std::sync::mpsc::Receiver;
+use std::sync::{Arc, RwLock};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RecordOptions {
+    pub enable: bool,
+    pub record_path: PathBuf,
+    pub windows_style_line_endings: bool,
+    pub write_header_line: bool,
+    pub insert_timestamp: bool,
+}
+
+impl Default for RecordOptions {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            record_path: PathBuf::new(),
+            windows_style_line_endings: false,
+            write_header_line: true,
+            insert_timestamp: true,
+        }
+    }
+}
+
+pub struct RecordData {
+    pub time: u128,
+    pub datas: Vec<f64>,
+}
+
+fn get_headers(
+    data_lock: &Arc<RwLock<DataContainer>>,
+    record_options: &RecordOptions,
+) -> Vec<String> {
+    let mut headers = vec![];
+    if record_options.insert_timestamp {
+        headers.push("Timestamp".to_owned());
+    }
+    if let Ok(read_guard) = data_lock.read() {
+        for name in &read_guard.names {
+            headers.push(name.clone());
+        }
+    }
+    headers
+}
+
+pub fn record_thread(
+    data_lock: Arc<RwLock<DataContainer>>,
+    print_lock: Arc<RwLock<Vec<Print>>>,
+    record_options_rx: Receiver<RecordOptions>,
+    record_data_rx: Receiver<RecordData>,
+) {
+    let mut record_options = RecordOptions::default();
+    let mut wtr: Option<Writer<File>> = None;
+    'record_loop: loop {
+        if let Ok(opt) = record_options_rx.try_recv() {
+            record_options = opt;
+        }
+
+        if record_options.enable {
+            if wtr.is_none() {
+                fs::remove_file(&record_options.record_path).unwrap_or_default();
+                wtr = match Writer::from_path(&record_options.record_path) {
+                    Ok(w) => Some(w),
+                    Err(e) => {
+                        print_to_console(
+                            &print_lock,
+                            Print::Error(format!("Error while create recorder: {:?}", e)),
+                        );
+                        record_options.enable = false;
+                        continue;
+                    }
+                };
+                if let Some(w) = &mut wtr {
+                    let headers = get_headers(&data_lock, &record_options);
+                    if let Err(e) = w.write_record(&headers) {
+                        print_to_console(
+                            &print_lock,
+                            Print::Error(format!("Error while create headers: {:?}", e)),
+                        );
+                    };
+                }
+            }
+            let datas_vec = match record_data_rx.try_recv() {
+                Ok(datas) => {
+                    let mut dv = vec![];
+                    if record_options.insert_timestamp {
+                        dv.push(datas.time.to_string())
+                    }
+                    for data in datas.datas {
+                        dv.push(data.to_string())
+                    }
+                    dv
+                }
+                Err(_) => continue 'record_loop,
+            };
+            if let Some(w) = &mut wtr {
+                if let Err(e) = w.write_record(&datas_vec) {
+                    print_to_console(
+                        &print_lock,
+                        Print::Error(format!("Error while record data: {:?}", e)),
+                    );
+                }
+                w.flush().unwrap_or_default();
+            } else {
+                record_options.enable = false;
+                continue;
+            }
+        } else {
+            wtr = None;
+            let _recv = record_data_rx.try_recv();
+        }
+    }
+}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -13,16 +13,12 @@ use crate::{print_to_console, Packet, Print, APP_INFO, PREFS_KEY_SERIAL};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SerialDevices {
     pub devices: Vec<Device>,
-    pub labels: Vec<Vec<String>>,
-    pub number_of_plots: Vec<usize>,
 }
 
 impl Default for SerialDevices {
     fn default() -> Self {
         SerialDevices {
             devices: vec![Device::default()],
-            labels: vec![vec!["Column 0".to_string()]],
-            number_of_plots: vec![1],
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,24 @@
+#[allow(dead_code)]
+pub fn truncate_tail<T>(vec: Vec<T>, len: usize) -> std::vec::Vec<T> {
+    // This is safe because:
+    //
+    // * the slice passed to `drop_in_place` is valid; the `len > self.len`
+    //   case avoids creating an invalid slice, and
+    // * the `len` of the vector is shrunk before calling `drop_in_place`,
+    //   such that no value will be dropped twice in case `drop_in_place`
+    //   were to panic once (if it panics twice, the program aborts).
+    unsafe {
+        // Note: It's intentional that this is `>` and not `>=`.
+        //       Changing it to `>=` has negative performance
+        //       implications in some cases. See #78884 for more.
+        if len > vec.len() {
+            return vec;
+        }
+        let remaining_len = vec.len() - len;
+        let (ptr, _, cap) = vec.into_raw_parts();
+        let new_ptr = ptr.add(remaining_len);
+        let s = core::ptr::slice_from_raw_parts_mut(ptr, remaining_len);
+        core::ptr::drop_in_place(s);
+        Vec::from_raw_parts(new_ptr, len, cap - remaining_len)
+    }
+}


### PR DESCRIPTION
Fix #95 . Retrieving the latest available device in each data transfer loop significantly slows down the transfer rate. This pr uses the BrokenPipe IO error to determine the disconnection externally.