### PR TITLE
Added required package to build from source on Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,34 @@ Currently [cargo bundle](https://github.com/burtonageo/cargo-bundle) only suppor
 bundles [see github issue](https://github.com/burtonageo/cargo-bundle/issues/77).
 As a work-around we can use [cargo wix](https://github.com/volks73/cargo-wix) to create a windows installer.
 
-On Linux first install the following:
+#### Ubuntu
+
+```sh
+sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
+cargo install cargo-bundle
+cargo bundle
+```
+#### Debian
 
 ```sh
 sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libudev-dev
+cargo install cargo-bundle
+cargo bundle
 ```
 
-After downloading  
-```cargo install cargo-bundle``` on linux and macOS or ```cargo install cargo-wix``` on windows
-run  
-```cargo bundle``` on linux and macOS or ```cargo wix``` on windows to create platform-executable bundles.
+#### macOS
 
-It can be compiled and run on all platforms.
+```sh
+cargo install cargo-bundle
+cargo bundle
+```
+
+#### Windows
+
+```sh
+cargo install cargo-wix
+cargo wix
+```
 
 ## Features:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ As a work-around we can use [cargo wix](https://github.com/volks73/cargo-wix) to
 On Linux first install the following:
 
 ```sh
-sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
+sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libudev-dev
 ```
 
 After downloading  


### PR DESCRIPTION
Compiling from source on Debian 14 failed with some errors, amongst them:
```The system library `libudev` required by crate `libudev-sys` was not found.```
After installing `libudev-dev` the error went away and the serial monitor compiled just fine. It hence seems to make sense to add this to the readme as build dependency.