### PR TITLE
Fix theme preference not being restored correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the `Serial Monitor` crate will be documented in this fil
 * Releases are now linked to libssl 3.4.1 on linux (built on Ubuntu 22.04)
 * allow to plot only every n-th point (max points is 5000, if dataset is larger, it will reduce it by showing only every
   2nd point. if it is larger than 10000 only every 3rd point etc...)
+* Fixed the theme preference setting not being properly restored after restarting the application
 
 ## 0.3.4
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crate::gui::{load_gui_settings, GuiCommand, MyApp, RIGHT_PANEL_WIDTH};
 use crate::io::{open_from_csv, save_to_csv, FileOptions};
 use crate::serial::{load_serial_settings, serial_devices_thread, serial_thread, Device};
 use crossbeam_channel::{select, Receiver, Sender};
-use eframe::egui::{vec2, ViewportBuilder, Visuals};
+use eframe::egui::{vec2, ViewportBuilder};
 use eframe::{egui, icon_data};
 use egui_plot::PlotPoint;
 use preferences::AppInfo;
@@ -349,7 +349,7 @@ fn main() {
             let mut fonts = egui::FontDefinitions::default();
             egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
             ctx.egui_ctx.set_fonts(fonts);
-            ctx.egui_ctx.set_visuals(Visuals::dark());
+            ctx.egui_ctx.set_theme(gui_settings.theme_preference);
             egui_extras::install_image_loaders(&ctx.egui_ctx);
 
             let repaint_signal = ctx.egui_ctx.clone();

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -2,7 +2,7 @@ use crate::gui::GuiSettingsContainer;
 #[cfg(feature = "self_update")]
 use crate::update::{check_update, update};
 use eframe::egui;
-use eframe::egui::{Align2, InnerResponse, Vec2, Visuals};
+use eframe::egui::{Align2, InnerResponse, Vec2};
 use egui_theme_switch::ThemeSwitch;
 #[cfg(feature = "self_update")]
 use self_update::restart::restart;
@@ -32,7 +32,7 @@ pub fn settings_window(
                     {
                         ui.ctx().set_theme(gui_conf.theme_preference);
                     };
-                    gui_conf.dark_mode = ui.visuals() == &Visuals::dark();
+                    gui_conf.dark_mode = ui.ctx().theme() == egui::Theme::Dark;
 
                     ui.end_row();
                     ui.end_row();


### PR DESCRIPTION
Hi,

I noticed that the theme preference is not being restored correctly.  This PR contains the necessary changes to make it work :)

---

Using `set_visuals(Visuals::dark())` in `main()` somehow interfered badly with the theme switching code such that a light theme was not restored properly.

Instead, the correct function to set the theme on startup is `set_theme()` and we should pass in the saved preference instead of hard-coding dark-mode.