### PR TITLE
Fix single column graph display

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -57,7 +57,7 @@ impl Default for DataContainer {
         DataContainer {
             time: vec![],
             absolute_time: vec![],
-            dataset: vec![vec![]],
+            dataset: vec![],
             raw_traffic: vec![],
             loaded_from_file: false,
         }


### PR DESCRIPTION
When receiving only a single column of data, no graph would ever show up.

This was due to the graph display data structure only being initialized when the number of datasets changes.  However, the dataset attribute is populated with one entry by default, so when receiving a single column of data, the graph initialization never happens.

Fix this by initializing the dataset structure to be empty by default.

This bug was introduced in PR #119.